### PR TITLE
add custom stack name

### DIFF
--- a/actions/build.js
+++ b/actions/build.js
@@ -303,6 +303,7 @@ function prepareDockerConfig(buildConfig) {
   var slackConfig = buildConfig.notifications.slack || {}
   var defaultDockerConfig = {
     env: {
+      STACK: config.STACK,
       LAMBCI_DOCKER_CMD: dockerConfig.cmd,
       LAMBCI_DOCKER_FILE: dockerConfig.file,
       LAMBCI_DOCKER_TAG: dockerConfig.tag,


### PR DESCRIPTION
overview
---

when using a custom stack name, the docker ecs image does not properly report back to the correct ci instance on github because it was hard coded to the default value

tasks
---
- [x] infer the ci instance from stack name
- [x] build and push new docker image to `slajax/lambci`
- [x] build and test with `slajax/lambci` and lambci/lambci#21
- [ ] build and push new docker image to `lambci/ecs`

closes lambci/ecs#17